### PR TITLE
Draw the touch gizmos on the camera's clip plane instead of the z=0 plane, which makes it work for any arbitrary camera angle

### DIFF
--- a/Assets/Plugins/TouchKit/Helpers/TouchKitEditorSupport.cs
+++ b/Assets/Plugins/TouchKit/Helpers/TouchKitEditorSupport.cs
@@ -102,17 +102,17 @@ public partial class TouchKit
 			{
 				if (touch.phase == TouchPhase.Began || touch.phase == TouchPhase.Moved || touch.phase == TouchPhase.Stationary)
 				{
-					var touchPos = Camera.main.ScreenToWorldPoint(Camera.main.transform.InverseTransformPoint(touch.position));
+                    var touchPos = Camera.main.ScreenToWorldPoint(new Vector3(touch.position.x, touch.position.y, Camera.main.nearClipPlane));
 					Gizmos.DrawIcon(touchPos, "greenPoint.png", false);
 				}
 			}
 			
 			if (_simulatedMultitouchStartPosition.HasValue && !_hasActiveSimulatedTouch)
 			{
-				var mousePos = Camera.main.ScreenToWorldPoint(Camera.main.transform.InverseTransformPoint(Input.mousePosition));
+                var mousePos = Camera.main.ScreenToWorldPoint(new Vector3(Input.mousePosition.x, Input.mousePosition.y, Camera.main.nearClipPlane));
 				Gizmos.DrawIcon(mousePos, "redPoint.png", false);
 				
-				var simulatedPos = Camera.main.ScreenToWorldPoint(Camera.main.transform.InverseTransformPoint(_simulatedMousePosition));
+                var simulatedPos = Camera.main.ScreenToWorldPoint(new Vector3(_simulatedMousePosition.x, _simulatedMousePosition.y, Camera.main.nearClipPlane));
 				Gizmos.DrawIcon(simulatedPos, "redPoint.png", false);
 			}
 		}


### PR DESCRIPTION
Draw the touch gizmos on the camera's clip plane instead of the z=0 plane, which makes it work for any arbitrary camera angle.
Before, the debug touches worked only when the camera was aligned with the z-axis, which makes them invisible when used in a 3D setting
