### PR TITLE
Draw the touch gizmos on the camera's clip plane

### DIFF
--- a/Assets/Plugins/TouchKit/Helpers/TouchKitEditorSupport.cs
+++ b/Assets/Plugins/TouchKit/Helpers/TouchKitEditorSupport.cs
@@ -102,17 +102,17 @@ public partial class TouchKit
 			{
 				if (touch.phase == TouchPhase.Began || touch.phase == TouchPhase.Moved || touch.phase == TouchPhase.Stationary)
 				{
-					var touchPos = Camera.main.ScreenToWorldPoint(Camera.main.transform.InverseTransformPoint(touch.position));
+                    var touchPos = Camera.main.ScreenToWorldPoint(new Vector3(touch.position.x, touch.position.y, Camera.main.farClipPlane));
 					Gizmos.DrawIcon(touchPos, "greenPoint.png", false);
 				}
 			}
 			
 			if (_simulatedMultitouchStartPosition.HasValue && !_hasActiveSimulatedTouch)
 			{
-				var mousePos = Camera.main.ScreenToWorldPoint(Camera.main.transform.InverseTransformPoint(Input.mousePosition));
+                var mousePos = Camera.main.ScreenToWorldPoint(new Vector3(Input.mousePosition.x, Input.mousePosition.y, Camera.main.farClipPlane));
 				Gizmos.DrawIcon(mousePos, "redPoint.png", false);
 				
-				var simulatedPos = Camera.main.ScreenToWorldPoint(Camera.main.transform.InverseTransformPoint(_simulatedMousePosition));
+                var simulatedPos = Camera.main.ScreenToWorldPoint(new Vector3(_simulatedMousePosition.x, _simulatedMousePosition.y, Camera.main.farClipPlane));
 				Gizmos.DrawIcon(simulatedPos, "redPoint.png", false);
 			}
 		}


### PR DESCRIPTION
Draw the touch gizmos on the camera's clip plane instead of the z=0 plane, which makes them work for any arbitrary camera angle.
Before, touches were only shown correctly when the camera faced the z axis, which works for most 2D or 2.5D games but not in 3D games where the camera's position and rotation is arbitrary
