### PR TITLE
BUGFIX: Static TouchKit instance not being created

### DIFF
--- a/Assets/TouchKit/TouchKit.cs
+++ b/Assets/TouchKit/TouchKit.cs
@@ -215,9 +215,7 @@ public partial class TouchKit : MonoBehaviour
 
 
 	public static void addGestureRecognizer( TKAbstractGestureRecognizer recognizer )
-	{
-        if (_instance == null) return;
-        
+	{       
         // add, then sort and reverse so the higher zIndex items will be on top
 		instance._gestureRecognizers.Add( recognizer );
 


### PR DESCRIPTION
Removed check for null instance in addGestureRecognizer() since it
was preventing the creation of the static TouchKit instance.
