### PR TITLE
Feature/distance in centimeters

### DIFF
--- a/Assets/TouchKit/Recognizers/TKLongPressRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKLongPressRecognizer.cs
@@ -14,7 +14,7 @@ public class TKLongPressRecognizer : TKAbstractGestureRecognizer
 	public event Action<TKLongPressRecognizer> gestureCompleteEvent; // fired when after a successful long press the finger is lifted
 
 	public float minimumPressDuration = 0.5f;
-	public float allowableMovement = 10f;
+	public float allowableMovementCm = 1f;
 
 	private Vector2 _beginLocation;
 	private bool _waiting;
@@ -27,7 +27,7 @@ public class TKLongPressRecognizer : TKAbstractGestureRecognizer
 	public TKLongPressRecognizer( float minimumPressDuration, float allowableMovement )
 	{
 		this.minimumPressDuration = minimumPressDuration;
-		this.allowableMovement = allowableMovement * TouchKit.instance.runtimeDistanceModifier;
+		this.allowableMovementCm = allowableMovementCm;
 	}
 
 
@@ -78,8 +78,8 @@ public class TKLongPressRecognizer : TKAbstractGestureRecognizer
 		if( state == TKGestureRecognizerState.Began || state == TKGestureRecognizerState.RecognizedAndStillRecognizing )
 		{
 			// did we move too far?
-			var moveDistance = Vector2.Distance( touches[0].position, _beginLocation );
-			if( moveDistance > allowableMovement )
+			var moveDistance = Vector2.Distance(touches[0].position, _beginLocation) / TouchKit.instance.ScreenPixelsPerCm;
+			if (moveDistance > allowableMovementCm)
 			{
 				// fire the complete event if we had previously recognized a long press
 				if( state == TKGestureRecognizerState.RecognizedAndStillRecognizing && gestureCompleteEvent != null )

--- a/Assets/TouchKit/Recognizers/TKPanRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKPanRecognizer.cs
@@ -11,17 +11,20 @@ public class TKPanRecognizer : TKAbstractGestureRecognizer
 	public event Action<TKPanRecognizer> gestureCompleteEvent;
 	
 	public Vector2 deltaTranslation;
-	public Vector2 totalDeltaTranslation = Vector2.zero;
+	public float deltaTranslationCm;
+
+	private float totalDeltaMovementInCm = 0f;
+
 	public int minimumNumberOfTouches = 1;
 	public int maximumNumberOfTouches = 2;
 	
 	private Vector2 _previousLocation;
-	private float _minDistanceToPan;
 
-	public TKPanRecognizer( float minPanDistance = 0f)
+	private float _minDistanceToPanCm;
+
+	public TKPanRecognizer(float minPanDistanceCm = 0.5f)
 	{
-		_minDistanceToPan = minPanDistance;
-		_minDistanceToPan = _minDistanceToPan * TouchKit.instance.runtimeDistanceModifier;
+		_minDistanceToPanCm = minPanDistanceCm;
 	}
 
 
@@ -54,7 +57,7 @@ public class TKPanRecognizer : TKAbstractGestureRecognizer
 				_previousLocation = touchLocation();
 				if( state != TKGestureRecognizerState.RecognizedAndStillRecognizing )
 				{
-					totalDeltaTranslation = Vector2.zero;
+					totalDeltaMovementInCm = 0f;
 					state = TKGestureRecognizerState.Began;
 				}
 			}
@@ -68,12 +71,15 @@ public class TKPanRecognizer : TKAbstractGestureRecognizer
 	{
 		var currentLocation = touchLocation();
 		deltaTranslation = currentLocation - _previousLocation;
+		deltaTranslationCm = deltaTranslation.magnitude / TouchKit.instance.ScreenPixelsPerCm;
 		_previousLocation = currentLocation;
-		totalDeltaTranslation += deltaTranslation;
 
 		if (state == TKGestureRecognizerState.Began)
 		{
-			if (totalDeltaTranslation.sqrMagnitude >= _minDistanceToPan)
+			totalDeltaMovementInCm += deltaTranslationCm;
+			Debug.Log(totalDeltaMovementInCm);
+
+			if (Math.Abs(totalDeltaMovementInCm) >= _minDistanceToPanCm)
 			{
 				state = TKGestureRecognizerState.RecognizedAndStillRecognizing;
 			}

--- a/Assets/TouchKit/Recognizers/TKPinchRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKPinchRecognizer.cs
@@ -17,7 +17,7 @@ public class TKPinchRecognizer : TKAbstractGestureRecognizer
 	
 	private float distanceBetweenTrackedTouches()
 	{
-		return Vector2.Distance( _trackingTouches[0].position, _trackingTouches[1].position );
+		return (Vector2.Distance(_trackingTouches[0].position, _trackingTouches[1].position) / TouchKit.instance.ScreenPixelsPerCm);
 	}
 	
 	

--- a/Assets/TouchKit/Recognizers/TKSwipeRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKSwipeRecognizer.cs
@@ -24,9 +24,9 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 	public float timeToSwipe = 0.5f;	
 	public float swipeVelocity { get; private set; }
 	public TKSwipeDirection completedSwipeDirection { get; private set; }
-	
-	private float _allowedVariance = 35.0f;
-	private float _minimumDistance = 40.0f;
+
+	private float _minimumDistance = 2f;
+	private float _allowedVariance = 1.5f;
 	private TKSwipeDirection _swipesToDetect = TKSwipeDirection.All;
 	
 	// swipe state info
@@ -50,25 +50,21 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 			return this._endPoint;
 		}
 	}
-	
-	
-	public TKSwipeRecognizer() : this( 40f, 35f )
-	{}
-	
-	
-	public TKSwipeRecognizer( TKSwipeDirection swipesToDetect ) : this( swipesToDetect, 40f, 35f )
-	{}
-	
-	
-	public TKSwipeRecognizer( float minimumDistance, float allowedVariance ) : this( TKSwipeDirection.All, minimumDistance, allowedVariance )
-	{}
-	
-	
-	public TKSwipeRecognizer( TKSwipeDirection swipesToDetect, float minimumDistance, float allowedVariance )
+
+	public TKSwipeRecognizer() : this(2f, 1.5f)
+	{ }
+
+	public TKSwipeRecognizer(TKSwipeDirection swipesToDetect) : this(swipesToDetect, 2f, 1.5f)
+	{ }
+
+	public TKSwipeRecognizer(float minimumDistance, float allowedVariance) : this(TKSwipeDirection.All, minimumDistance, allowedVariance)
+	{ }
+
+	public TKSwipeRecognizer(TKSwipeDirection swipesToDetect, float minimumDistanceCm, float allowedVarianceCm)
 	{
 		_swipesToDetect = swipesToDetect;
-		_minimumDistance = minimumDistance * TouchKit.instance.runtimeDistanceModifier;
-		_allowedVariance = allowedVariance * TouchKit.instance.runtimeDistanceModifier;
+		_minimumDistance = minimumDistanceCm;
+		_allowedVariance = allowedVarianceCm;
 	}
 
 	
@@ -105,9 +101,9 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 
         //Debug.Log( string.Format( "swipeStatus: {0}", swipeDetectionState ) );
 
-        // Grab the total distance moved in both directions
-        var xDeltaAbs = Mathf.Abs( _startPoint.x - touch.position.x );
-		var yDeltaAbs = Mathf.Abs( _startPoint.y - touch.position.y );
+		// Grab the total distance moved in both directions
+		var xDeltaAbsCm = Mathf.Abs(_startPoint.x - touch.position.x) / TouchKit.instance.ScreenPixelsPerCm;
+		var yDeltaAbsCm = Mathf.Abs(_startPoint.y - touch.position.y) / TouchKit.instance.ScreenPixelsPerCm;
 
 		_endPoint = touch.position;
 
@@ -115,12 +111,12 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 		// left check
 		if( ( _swipeDetectionState & TKSwipeDirection.Left ) != 0 )
 		{
-			if( xDeltaAbs > _minimumDistance )
+			if (xDeltaAbsCm > _minimumDistance)
 			{
-				if( yDeltaAbs < _allowedVariance )
+				if (yDeltaAbsCm < _allowedVariance)
 				{
 					completedSwipeDirection = TKSwipeDirection.Left;
-					swipeVelocity = xDeltaAbs / ( Time.time - _startTime );
+					swipeVelocity = xDeltaAbsCm / (Time.time - _startTime);
 					return true;
 				}
 				
@@ -132,12 +128,12 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 		// right check
 		if( ( _swipeDetectionState & TKSwipeDirection.Right ) != 0 )
 		{
-			if( xDeltaAbs > _minimumDistance )
+			if (xDeltaAbsCm > _minimumDistance)
 			{
-				if( yDeltaAbs < _allowedVariance )
+				if (yDeltaAbsCm < _allowedVariance)
 				{
 					completedSwipeDirection = TKSwipeDirection.Right;
-					swipeVelocity = xDeltaAbs / ( Time.time - _startTime );
+					swipeVelocity = xDeltaAbsCm / (Time.time - _startTime);
 					return true;
 				}
 				
@@ -149,12 +145,12 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 		// up check
 		if( ( _swipeDetectionState & TKSwipeDirection.Up ) != 0 )
 		{
-			if( yDeltaAbs > _minimumDistance )
+			if (yDeltaAbsCm > _minimumDistance)
 			{
-				if( xDeltaAbs < _allowedVariance )
+				if (xDeltaAbsCm < _allowedVariance)
 				{
 					completedSwipeDirection = TKSwipeDirection.Up;
-					swipeVelocity = yDeltaAbs / ( Time.time - _startTime );
+					swipeVelocity = yDeltaAbsCm / (Time.time - _startTime);
 					return true;
 				}
 				
@@ -166,12 +162,12 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 		// cown check
 		if( ( _swipeDetectionState & TKSwipeDirection.Down ) != 0 )
 		{
-			if( yDeltaAbs > _minimumDistance )
+			if (yDeltaAbsCm > _minimumDistance)
 			{
-				if( xDeltaAbs < _allowedVariance )
+				if (xDeltaAbsCm < _allowedVariance)
 				{
 					completedSwipeDirection = TKSwipeDirection.Down;
-					swipeVelocity = yDeltaAbs / ( Time.time - _startTime );
+					swipeVelocity = yDeltaAbsCm / (Time.time - _startTime);
 					return true;
 				}
 				

--- a/Assets/TouchKit/Recognizers/TKTapRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKTapRecognizer.cs
@@ -13,20 +13,18 @@ public class TKTapRecognizer : TKAbstractGestureRecognizer
 
 	// taps that last longer than this duration will be ignored
 	private float _maxDurationForTapConsideration = 0.5f;
-	private float _maxDeltaMovementForTapConsideration = 5f;
+
+	private float _maxDeltaMovementForTapConsideration = 1f;
 
 	private float _touchBeganTime;
 
+	public TKTapRecognizer() : this(0.5f, 1f)
+	{ }
 
-
-	public TKTapRecognizer() : this( 0.5f, 5f )
-	{}
-
-
-	public TKTapRecognizer( float maxDurationForTapConsideration, float maxDeltaMovementForTapConsideration )
+	public TKTapRecognizer(float maxDurationForTapConsideration, float maxDeltaMovementForTapConsiderationCm)
 	{
 		_maxDurationForTapConsideration = maxDurationForTapConsideration;
-		_maxDeltaMovementForTapConsideration = maxDeltaMovementForTapConsideration * TouchKit.instance.runtimeDistanceModifier;
+		_maxDeltaMovementForTapConsideration = maxDeltaMovementForTapConsiderationCm;
 	}
 
 
@@ -73,7 +71,10 @@ public class TKTapRecognizer : TKAbstractGestureRecognizer
 			// did we move?
 			for( var i = 0; i < touches.Count; i++ )
 			{
-				if( (touches[i].position - touches[i].startPosition).sqrMagnitude > _maxDeltaMovementForTapConsideration )
+				if (
+					((Math.Abs(touches[i].position.x - touches[i].startPosition.x) / TouchKit.instance.ScreenPixelsPerCm) > _maxDeltaMovementForTapConsideration) ||
+					((Math.Abs(touches[i].position.y - touches[i].startPosition.y) / TouchKit.instance.ScreenPixelsPerCm) > _maxDeltaMovementForTapConsideration)
+				)
 				{
 					state = TKGestureRecognizerState.FailedOrEnded;
 					break;

--- a/Assets/TouchKit/TouchKit.cs
+++ b/Assets/TouchKit/TouchKit.cs
@@ -52,6 +52,16 @@ public partial class TouchKit : MonoBehaviour
 	private List<TKTouch> _liveTouches = new List<TKTouch>( 2 );
 	private bool _shouldCheckForLostTouches = false; // used internally to ensure we dont check for lost touches too often
 
+	private const float inchesToCentimeters = 2.54f;
+
+	public float ScreenPixelsPerCm
+	{
+		get
+		{
+			float dpi = Screen.dpi;
+			return dpi == 0f ? 72f / inchesToCentimeters : dpi / inchesToCentimeters;
+		}
+	}
 
 	private static TouchKit _instance = null;
 	public static TouchKit instance
@@ -73,7 +83,7 @@ public partial class TouchKit : MonoBehaviour
 
 				// prep the scalers. for the distance scaler we just use an average of the width and height scales
 				var aCamera = Camera.main ?? Camera.allCameras[0];
-				if( aCamera.isOrthoGraphic )
+				if( aCamera.orthographic )
 				{
 					setupPixelsToUnityUnitsMultiplierWithCamera( aCamera );
 				}
@@ -206,7 +216,7 @@ public partial class TouchKit : MonoBehaviour
 	/// <param name="cam">Cam.</param>
 	public static void setupPixelsToUnityUnitsMultiplierWithCamera( Camera cam )
 	{
-		if( !cam.isOrthoGraphic )
+		if( !cam.orthographic )
 		{
 			Debug.LogError( "Attempting to setup unity pixel-to-units modifier with a non-orthographic camera" );
 			return;


### PR DESCRIPTION
Main motivation was to be able to express distance of touch input by centimeters rather than abstract pixel value against a reference design resolution.

So for example constructing TKSwipeRecogniser(2f, 1.5f) describes a swipe with a distance of 2cm and variance of 1.5cm

This is achieved by using Unity's Screen.DPI value as a method on TouchKit instance. Note this is supported for almost all devices, we use a fallback of 72 dpi if not (e.g. Editor).

Finally the code is upgraded to reflect Unity 5 