### PR TITLE
Change TKTouch reference to TKLTouch

### DIFF
--- a/Assets/TouchKitLite/TLKSwipeDetector.cs
+++ b/Assets/TouchKitLite/TLKSwipeDetector.cs
@@ -67,7 +67,7 @@ public class TLKSwipeDetector : MonoBehaviour
 	}
 
 
-	private bool checkForSwipeCompletion( TKTouch touch )
+	private bool checkForSwipeCompletion( TKLTouch touch )
 	{
 		// if we have a time stipulation and we exceeded it stop listening for swipes
 		if( timeToSwipe > 0.0f && ( Time.time - _startTime ) > timeToSwipe )


### PR DESCRIPTION
It seems the TLKSwipeDetector was referencing TKTouch, which isn't part of the "Lite" files. Updated to reference TKLTouch instead.