### PR TITLE
Revamped TKAngleSwipeRecognizer to fix flaw/bug with angle bound triggered events.

### DIFF
--- a/Assets/TouchKit/Recognizers/TKAngleSwipeRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKAngleSwipeRecognizer.cs
@@ -1,129 +1,122 @@
 ﻿using UnityEngine;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-
 
 public class TKAngleSwipeRecognizer : TKAbstractGestureRecognizer
 {
 
 	public event Action<TKAngleSwipeRecognizer> gestureRecognizedEvent;
 
-	struct AngleListener
+	private struct AngleListener
 	{
-		public float MinAngle;
-		public float MaxAngle;
+		public float Varience;
+		public Vector2 Direction;
 		public Action<TKAngleSwipeRecognizer> Action;
 
-		public AngleListener( float minAngle, float maxAngle, Action<TKAngleSwipeRecognizer> action ) : this()
+		public AngleListener (Vector2 direction, float varience, Action<TKAngleSwipeRecognizer> action) : this ()
 		{
-			MinAngle = minAngle;
-			MaxAngle = maxAngle;
+			Varience = varience;
+			Direction = direction;
 			Action = action;
 		}
 	}
 
-	List<AngleListener> _angleRecognizedEvents = new List<AngleListener>();
+	private List<AngleListener> _angleRecognizedEvents = new List<AngleListener> ();
 
 	public float timeToSwipe = 0.5f;
 
-	public float swipeVelocity { get; set; }
+	public float swipeVelocity { get; private set; }
 
-	public float swipeAngle { get; set; }
+	public float swipeAngle { get; private set; }
 
-	public Vector2 startPoint
-	{
+	public Vector2 swipeVelVector { get; private set; }
+
+	public float minimumDistance = 2f;
+
+	// swipe state info
+	private Vector2 _startPoint;
+	private Vector2 _endPoint;
+	private float _startTime;
+
+	public Vector2 startPoint {
 		get { return this._startPoint; }
 	}
 
-	public Vector2 endPoint
-	{
+	public Vector2 endPoint {
 		get { return this._endPoint; }
 	}
 
-	float _minimumDistance = 2f;
-
-	// swipe state info
-	Vector2 _startPoint;
-	Vector2 _endPoint;
-	float _startTime;
-
-
-	public TKAngleSwipeRecognizer() : this( 2f )
+	public TKAngleSwipeRecognizer () : this (2f)
 	{
 	}
 
-
-	public TKAngleSwipeRecognizer( float minimumDistanceCm )
+	public TKAngleSwipeRecognizer (float minimumDistanceCm)
 	{
-		_minimumDistance = minimumDistanceCm;
+		minimumDistance = minimumDistanceCm;
 	}
 
-
-	public void addAngleRecogizedEvents( Action<TKAngleSwipeRecognizer> action, float minAngle, float maxAngle )
+	public void addAngleRecogizedEvents (Action<TKAngleSwipeRecognizer> action, Vector2 direction, float angleVarience)
 	{
-		_angleRecognizedEvents.Add( new AngleListener( minAngle, maxAngle, action ) );
+		_angleRecognizedEvents.Add (new AngleListener (direction, angleVarience, action));
 	}
 
-
-	public void removeAngleRecognizedEvents( Action<TKAngleSwipeRecognizer> action )
+	public void removeAngleRecognizedEvents (Action<TKAngleSwipeRecognizer> action)
 	{
-		_angleRecognizedEvents.RemoveAll(
-			(AngleListener listener ) =>
-			{
+		_angleRecognizedEvents.RemoveAll (
+			(AngleListener listener) =>  {
 				return listener.Action == action;
-			} );
+			});
 	}
 
-
-	public void removeAllAngleRecongnizedEvents()
+	public void removeAllAngleRecongnizedEvents ()
 	{
-		_angleRecognizedEvents.Clear();
+		_angleRecognizedEvents.Clear ();
 	}
 
-
-	public void fireAngleRecognizedEvents()
+	public void fireAngleRecognizedEvents ()
 	{
-		for( int i = 0, length = _angleRecognizedEvents.Count; i < length; i++ )
+		for (int i = 0, length = _angleRecognizedEvents.Count; i < length; i++) 
 		{
-			var angleEvent = _angleRecognizedEvents[i];
-			if( angleEvent.MinAngle <= swipeAngle && angleEvent.MaxAngle >= swipeAngle )
+			var angleEvent = _angleRecognizedEvents [i];
+			if (angleEvent.Varience > Vector2.Angle (angleEvent.Direction, swipeVelVector)) 
 			{
-				angleEvent.Action( this );
+				angleEvent.Action (this);
 			}
 		}
 	}
 
-
-	bool checkForSwipeCompletion( TKTouch touch )
+	private bool checkForSwipeCompletion (TKTouch touch)
 	{
 		// if we have a time stipulation and we exceeded it stop listening for swipes
-		if( timeToSwipe > 0.0f && ( Time.time - _startTime ) > timeToSwipe )
+		if (timeToSwipe > 0.0f && (Time.time - _startTime) > timeToSwipe) 
 		{
 			state = TKGestureRecognizerState.FailedOrEnded;
 			return false;
 		}
 
 		// Grab the total distance moved in both directions
-		var xDeltaAbsCm = Mathf.Abs( _startPoint.x - touch.position.x ) / TouchKit.instance.ScreenPixelsPerCm;
-		var yDeltaAbsCm = Mathf.Abs( _startPoint.y - touch.position.y ) / TouchKit.instance.ScreenPixelsPerCm;
+		var xDeltaAbsCm = Mathf.Abs (_startPoint.x - touch.position.x) / TouchKit.instance.ScreenPixelsPerCm;
+		var yDeltaAbsCm = Mathf.Abs (_startPoint.y - touch.position.y) / TouchKit.instance.ScreenPixelsPerCm;
 
 		_endPoint = touch.position;
 
 		// Get the velocity
-		swipeVelocity = Mathf.Sqrt( xDeltaAbsCm * xDeltaAbsCm + yDeltaAbsCm * yDeltaAbsCm );
+		swipeVelocity = Mathf.Sqrt (xDeltaAbsCm * xDeltaAbsCm + yDeltaAbsCm * yDeltaAbsCm);
 
 		// Calculate the movement vector
 		var displacement = endPoint - startPoint;
 		// Calculate the angle with respect to the x axis
-		swipeAngle = Mathf.Rad2Deg * Mathf.Atan2( displacement.y, displacement.x );
+		swipeAngle = Mathf.Rad2Deg * Mathf.Atan2 (displacement.y, displacement.x);
 		// Get it between 0 to 360
-		if( swipeAngle < 0 )
+		if (swipeAngle < 0) 
 		{
 			swipeAngle += 360;
 		}
+
+		swipeVelVector = _endPoint - _startPoint;
+
 		// If we have enough distance, then return true
-		if( swipeVelocity > _minimumDistance )
+		if (swipeVelocity > minimumDistance) 
 		{
 			return true;
 		}
@@ -132,23 +125,23 @@ public class TKAngleSwipeRecognizer : TKAbstractGestureRecognizer
 	}
 
 
-	internal override void fireRecognizedEvent()
+	internal override void fireRecognizedEvent ()
 	{
-		if( gestureRecognizedEvent != null )
+		if (gestureRecognizedEvent != null) 
 		{
-			gestureRecognizedEvent( this );
+			gestureRecognizedEvent (this);
 		}
-		fireAngleRecognizedEvents();
+		fireAngleRecognizedEvents ();
 	}
 
 
-	internal override bool touchesBegan( List<TKTouch> touches )
+	internal override bool touchesBegan (List<TKTouch> touches)
 	{
-		if( state == TKGestureRecognizerState.Possible )
+		if (state == TKGestureRecognizerState.Possible) 
 		{
-			_startPoint = touches[0].position;
+			_startPoint = touches [0].position;
 			_startTime = Time.time;
-			_trackingTouches.Add( touches[0] );
+			_trackingTouches.Add (touches [0]);
 
 			state = TKGestureRecognizerState.Began;
 		}
@@ -156,11 +149,11 @@ public class TKAngleSwipeRecognizer : TKAbstractGestureRecognizer
 	}
 
 
-	internal override void touchesMoved( List<TKTouch> touches )
+	internal override void touchesMoved (List<TKTouch> touches)
 	{
-		if( state == TKGestureRecognizerState.Began )
+		if (state == TKGestureRecognizerState.Began) 
 		{
-			if( checkForSwipeCompletion( touches[0] ) )
+			if (checkForSwipeCompletion (touches [0])) 
 			{
 				state = TKGestureRecognizerState.Recognized;
 			}
@@ -168,15 +161,14 @@ public class TKAngleSwipeRecognizer : TKAbstractGestureRecognizer
 	}
 
 
-	internal override void touchesEnded( List<TKTouch> touches )
+	internal override void touchesEnded (List<TKTouch> touches)
 	{
 		state = TKGestureRecognizerState.FailedOrEnded;
 	}
 
-
-	public override string ToString()
+	public override string ToString ()
 	{
-		return string.Format( "{0}, velocity: {1}, angle: {2}, start point: {3}, end point: {4}",
-			base.ToString(), swipeVelocity, swipeAngle, startPoint, endPoint );
+		return string.Format ("{0}, velocity: {1}, angle: {2}, start point: {3}, end point: {4}",
+			base.ToString (), swipeVelocity, swipeAngle, startPoint, endPoint);
 	}
 }

--- a/Assets/TouchKitDemos/DemoOne/DemoOne.cs
+++ b/Assets/TouchKitDemos/DemoOne/DemoOne.cs
@@ -112,7 +112,7 @@ public class DemoOne : MonoBehaviour
 			recognizer.addAngleRecogizedEvents (
 				(TKAngleSwipeRecognizer r) => {
 					Debug.Log( "Top-Right angle swipe fired " + r );
-				}, 0, 90 );
+				}, new Vector2(1,1), 45);
 
 			recognizer.gestureRecognizedEvent += r => {
 				// You can also do ordinary event, which fires at any angle


### PR DESCRIPTION
**Bug:**
The old system was flawed because, for instance, if I want an event between of all swipes to the right, it was impossible to set up because the bounding angles are 270 to 90.

**Fix:**
The newest version instead takes in direction and allowed angle variance, so an event of trigger of all swipes to the right would be Direction {1,0}, and angle variance 90 degrees.