### PR TITLE
Update to TKSwipeRecognizer.cs Logic

### DIFF
--- a/Assets/TouchKit/Recognizers/TKSwipeRecognizer.cs
+++ b/Assets/TouchKit/Recognizers/TKSwipeRecognizer.cs
@@ -151,22 +151,21 @@ public class TKSwipeRecognizer : TKAbstractGestureRecognizer
 
     internal override void touchesMoved(List<TKTouch> touches)
     {
-        // if we have a time stipulation and we exceeded it stop listening for swipes, fail
-        if (timeToSwipe > 0.0f && (Time.time - startTime) > timeToSwipe)
+        if(state == TKGestureRecognizerState.Began)
         {
-            state = TKGestureRecognizerState.FailedOrEnded;
-        }
-        else if (state == TKGestureRecognizerState.Began)
-        {
-            points.Add(touches[0].position);
+            // if we have a time stipulation and we exceeded it, fail
+            if (timeToSwipe > 0.0f && (Time.time - startTime) > timeToSwipe)
+                state = TKGestureRecognizerState.FailedOrEnded;
+            else
+                points.Add(touches[0].position);
         }
     }
 
     internal override void touchesEnded(List<TKTouch> touches)
     {
-        // if we haven't failed yet, add the final point and then check for swipe completion
         if (state == TKGestureRecognizerState.Began)
         {
+            // if we haven't failed yet, add the final point and then check for swipe completion
             points.Add(touches[0].position);
 
             if (checkForSwipeCompletion(touches[0]))


### PR DESCRIPTION
The old version would detect swipes the moment the criteria for a "swipe" was met- this means checking for that criteria every single frame and firing the event mid-swipe before the finger is released, it would only detect swipes in the four cardinal directions, and it stored and checked no information about the intermediary points within the motion- only the first and final touch positions.

In this updated version, the criteria for a successful swipe are checked and (if successful) the event fired **only in the frame that the touch ends** (when the finger is picked up from the screen). In addition, four more directions have been added to the possible swipe recognition list for the four diagonal directions, an additional check is performed for "line straightness" which takes the total cumulative point-to-point distances for all sampled positions during the swipe motion and compares it to the "ideal distance" from the starting to ending points- failing if the cumulative total is more than 10% greater than the ideal (motion not straight enough). This keeps fast "V" motions on the screen from registering as directional swipes.